### PR TITLE
speed up build time by removing static lib gen

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -62,18 +62,10 @@ llvm_map_components_to_libnames(llvm_libs
     globalisel
 )
 
-add_library(convert_static STATIC ${SOURCES})
-set_target_properties(convert_static PROPERTIES
-    OUTPUT_NAME "convert"
+add_library(backend STATIC ${SOURCES})
+set_target_properties(backend PROPERTIES
+    OUTPUT_NAME "backend"
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../frontend/lib
 )
 
-add_library(convert SHARED ${SOURCES})
-set_target_properties(convert PROPERTIES
-    OUTPUT_NAME "convert"
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../frontend/lib
-    PREFIX "dll"  # OCaml expects 'dllconvert.so'
-)
-
-target_link_libraries(convert PRIVATE ${llvm_libs} ${SYSTEM_LIBS})
-target_link_libraries(convert_static PRIVATE ${llvm_libs} ${SYSTEM_LIBS})
+target_link_libraries(backend PRIVATE ${llvm_libs} ${SYSTEM_LIBS})

--- a/backend/src/codegen/decl.cpp
+++ b/backend/src/codegen/decl.cpp
@@ -38,7 +38,7 @@ void DeclToLLVisitor::codegenFunctionProto(const FDecl& fn) {
 
     llvm::Function* llfn = llvm::Function::Create(ftyp, linkage, fn.fname, gen.mod.get());
     if (fn.isInline)
-        llfn->addFnAttr(llvm::Attribute::InlineHint);
+        llfn->addFnAttr(llvm::Attribute::AlwaysInline);
 
     unsigned idx = 0;
     for (auto& arg : llfn->args()) {

--- a/frontend/src/desugaring/dune
+++ b/frontend/src/desugaring/dune
@@ -11,8 +11,8 @@
  (preprocess
   (pps ppx_deriving.show))
  (libraries core typing util fmt zarith)
- (foreign_archives ../../lib/convert)
- (modes byte native)
+ (foreign_archives ../../lib/backend)
+ (modes native)
  (c_library_flags
   (:standard
    -lstdc++


### PR DESCRIPTION
nearly halves build time by removing generation of static bytecode library for frontend to consume. 