### PR TITLE
Setup github ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
 .git
 .vscode
+.github
+.agents
+
 backend/build
 frontend/_build
 frontend/lib
+
 blink
 new_output.ll
 new_output.o

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Record runner IDs
+        id: runner
+        shell: bash
+        run: |
+          echo "uid=$(id -u)" >> "$GITHUB_OUTPUT"
+          echo "gid=$(id -g)" >> "$GITHUB_OUTPUT"
+
+      - name: Build cached toolchain image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: blink-ci:${{ github.sha }}
+          build-args: |
+            USER_ID=${{ steps.runner.outputs.uid }}
+            GROUP_ID=${{ steps.runner.outputs.gid }}
+          cache-from: type=gha,scope=blink-toolchain
+          cache-to: type=gha,mode=max,scope=blink-toolchain
+
+      - name: Build compiler and run all tests
+        shell: bash
+        run: |
+          docker run --rm --init \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "blink-ci:${GITHUB_SHA}" \
+            bash -c 'make && make test'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG OCAML_VERSION=4.14.2
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Native build tools and the system libraries required by OCaml packages and LLVM.
-RUN apt-get update \
-    && apt-get install --yes --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install --yes --no-install-recommends \
         build-essential \
         ca-certificates \
         cmake \
@@ -25,12 +25,13 @@ RUN apt-get update \
         pkg-config \
         python3-dev \
     && curl --fail --silent --show-error --location \
+        --retry 5 --retry-all-errors --retry-delay 2 \
         https://apt.llvm.org/llvm-snapshot.gpg.key \
         | gpg --dearmor --output /usr/share/keyrings/llvm-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-16 main" \
         > /etc/apt/sources.list.d/llvm.list \
-    && apt-get update \
-    && apt-get install --yes --no-install-recommends \
+    && apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install --yes --no-install-recommends \
         clang-16 \
         lld-16 \
         llvm-16 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
         libgmp-dev \
         libxml2-dev \
         libz-dev \
+        libzstd-dev \
         m4 \
         ninja-build \
         opam \

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ To build the frontend, you can simply run `dune build` in `frontend/`.
 
 ### Tests
 
+Every push and pull request runs the complete test suite in GitHub Actions.
+The workflow builds the repository's development container and caches its
+BuildKit layers in GitHub's cache service. LLVM 16, OCaml 4.14.2, and OPAM
+dependencies are therefore rebuilt only when the Dockerfile or
+`frontend/blink.opam` changes.
+
+The CI image uses the same environment as local Docker development, so the
+commands exercised in CI are simply:
+
+```sh
+make
+make test
+```
+
 Run all frontend unit tests and compiler end-to-end tests from the repository
 root:
 


### PR DESCRIPTION
Sets up GitHub ci to run tests on new pushes. Also caches expensive dependencies so we do not refetch them for every run